### PR TITLE
TODO一覧のビュー作成(TODO機能の実装①)

### DIFF
--- a/app/assets/stylesheets/_share.scss
+++ b/app/assets/stylesheets/_share.scss
@@ -79,7 +79,7 @@
 }
 
 .whole-page  {
-  background-color: #FAF9F5;
+  background-color: $background-color;
   padding-bottom: 2rem;
   height: 100%;
   min-height: 100vh;

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -1,6 +1,12 @@
 .task-index {
-  margin-top: 20px;
+  .task-nav {
+    margin-bottom: 0 !important;
+    vertical-align: middle;
+  }
   &__book-title {
+    p {
+      margin-bottom: 0;
+    }
     font-size: 1.2rem;
   }
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,1 +1,2 @@
 $accent-color: #C92334;
+$background-color: #FAF9F5;

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,9 +5,6 @@ class TasksController < ApplicationController
     reviews = Review.where(user_id: current_user.id).order("reviews.created_at DESC").includes(:book, :tasks)
     @unfinished_task_reviews = reviews.where(tasks: {finished: 0}).page(params[:page]).per(5)    
     @finished_task_reviews = reviews.where(tasks: {finished: 1}).page(params[:page]).per(5)
-
-    # has_task_reviews = Review.where(id: Task.select(:review_id).group(:review_id).having("count(review_id)>=?", 1))
-    # @reviews = has_task_reviews.where(user_id: current_user.id).page(params[:page]).per(5).order("created_at DESC").includes(:book, :tasks)  
   end
 
   def new; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,8 +2,12 @@ class TasksController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    has_task_reviews = Review.where(id: Task.select(:review_id).group(:review_id).having("count(review_id)>=?", 1))
-    @reviews = has_task_reviews.where(user_id: current_user.id).page(params[:page]).per(5).order("created_at DESC").includes(:book, :tasks)
+    reviews = Review.where(user_id: current_user.id).order("reviews.created_at DESC").includes(:book, :tasks)
+    @unfinished_task_reviews = reviews.where(tasks: {finished: 0}).page(params[:page]).per(5)    
+    @finished_task_reviews = reviews.where(tasks: {finished: 1}).page(params[:page]).per(5)
+
+    # has_task_reviews = Review.where(id: Task.select(:review_id).group(:review_id).having("count(review_id)>=?", 1))
+    # @reviews = has_task_reviews.where(user_id: current_user.id).page(params[:page]).per(5).order("created_at DESC").includes(:book, :tasks)  
   end
 
   def new; end

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -4,12 +4,33 @@
       = render "shared/sidebar"
       .col-sm-9.col-md-9
         .card.task-index
-          - @reviews.each do |review|
-            .card-header.task-index__book-title
-              = link_to review_path(review) do
-                = simple_format(review.book.title) 
-            .card-body.task-index__tasks
-              - review.tasks.each do |task|
-                = simple_format(task.task_content)
-        = paginate(@reviews)
-      
+          %ul#pills-tab.nav.nav-pills.mb-3{role: "tablist"}
+            %li.nav-item
+              %a#pills-unfinished-tab.nav-link.active{"aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", href: "#pills-unfinished", role: "tab"} 未実行
+            %li.nav-item
+              %a#pills-finished-tab.nav-link{"aria-controls" => "pills-finished", "aria-selected" => "false", "data-toggle" => "pill", href: "#pills-finished", role: "tab"} 完了済み
+          #pills-tabContent.tab-content
+            #pills-unfinished.tab-pane.fade.show.active{"aria-labelledby" => "pills-unfinished-tab", :role => "tabpanel"} 
+              - if @unfinished_task_reviews.present?
+                - @unfinished_task_reviews.each do |review|
+                  .card-header.task-index__book-title
+                    = link_to review_path(review) do
+                      = simple_format(review.book.title) 
+                  .card-body.task-index__tasks
+                    - review.tasks.each do |task|
+                      = simple_format(task.task_content)
+              - else 
+                未実行のタスクはありません。
+            = paginate(@unfinished_task_reviews)
+            #pills-finished.tab-pane.fade{"aria-labelledby" => "pills-finished-tab", :role => "tabpanel"} 
+              - if @finished_task_reviews.present?
+                - @finished_task_reviews.each do |review|
+                  .card-header.task-index__book-title
+                    = link_to review_path(review) do
+                      = simple_format(review.book.title) 
+                  .card-body.task-index__tasks
+                    - review.tasks.each do |task|
+                      = simple_format(task.task_content)
+              - else 
+                完了済みのタスクはありません。
+            = paginate(@finished_task_reviews)

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,9 +6,9 @@
         .card.task-index
           %ul#pills-tab.nav.nav-pills.mb-3{role: "tablist"}
             %li.nav-item
-              %a#pills-unfinished-tab.nav-link.active{"aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", href: "#pills-unfinished", role: "tab"} 未実行
+              = link_to "未実行", "#pills-unfinished", {id: "pills-unfinished-tab", class: "nav-link active", "aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", role: "tab"}
             %li.nav-item
-              %a#pills-finished-tab.nav-link{"aria-controls" => "pills-finished", "aria-selected" => "false", "data-toggle" => "pill", href: "#pills-finished", role: "tab"} 完了済み
+              = link_to "完了済み", "#pills-finished", {id: "pills-finished-tab", class: "nav-link", "aria-controls" => "pills-finished", "aria-selected" => "false", "data-toggle" => "pill", role: "tab"}
           #pills-tabContent.tab-content
             #pills-unfinished.tab-pane.fade.show.active{"aria-labelledby" => "pills-unfinished-tab", :role => "tabpanel"} 
               - if @unfinished_task_reviews.present?

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,9 +6,9 @@
         .card.task-index
           %ul#pills-tab.nav.nav-pills.mb-3.task-nav{role: "tablist"}
             %li.nav-item
-              = link_to "未実行", "#pills-unfinished", {id: "pills-unfinished-tab", class: "nav-link active", "aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", role: "tab"}
+              = link_to "TODO", "#pills-unfinished", {id: "pills-unfinished-tab", class: "nav-link active", "aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", role: "tab"}
             %li.nav-item
-              = link_to "完了済み", "#pills-finished", {id: "pills-finished-tab", class: "nav-link", "aria-controls" => "pills-finished", "aria-selected" => "false", "data-toggle" => "pill", role: "tab"}
+              = link_to "DONE", "#pills-finished", {id: "pills-finished-tab", class: "nav-link", "aria-controls" => "pills-finished", "aria-selected" => "false", "data-toggle" => "pill", role: "tab"}
           #pills-tabContent.tab-content
             #pills-unfinished.tab-pane.fade.show.active{"aria-labelledby" => "pills-unfinished-tab", :role => "tabpanel"} 
               - if @unfinished_task_reviews.present?
@@ -20,7 +20,7 @@
                     - review.tasks.each do |task|
                       = simple_format(task.task_content)
               - else 
-                未実行のタスクはありません。
+                未完了のタスクはありません。
             = paginate(@unfinished_task_reviews)
             #pills-finished.tab-pane.fade{"aria-labelledby" => "pills-finished-tab", :role => "tabpanel"} 
               - if @finished_task_reviews.present?

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -4,7 +4,7 @@
       = render "shared/sidebar"
       .col-sm-9.col-md-9
         .card.task-index
-          %ul#pills-tab.nav.nav-pills.mb-3{role: "tablist"}
+          %ul#pills-tab.nav.nav-pills.mb-3.task-nav{role: "tablist"}
             %li.nav-item
               = link_to "未実行", "#pills-unfinished", {id: "pills-unfinished-tab", class: "nav-link active", "aria-controls" => "pills-unfinished", "aria-selected" => "true", "data-toggle" => "pill", role: "tab"}
             %li.nav-item


### PR DESCRIPTION
## What
登録したTODO項目を一覧表示できるビューを作成しました。
「TODO」と「DONE」に分けて、それぞれの状態を表示できるようにしました。

## Why
サービスに必須の機能となるため。

## 今回保留した作業と今後のTODO
- タスクの登録画面を作成する必要があります。
- 一覧画面において、非同期通信で実行状況を更新できるようにすることを想定しています。

## 備考（実装にあたって参考にした情報など）
- [Bootstrap移行ガイド ナビゲーション](https://cccabinet.jpn.org/bootstrap4/components/navs)
- [Railsで子テーブルのレコードでwhereメソッドを使って条件検索する方法](https://hi-algorithm.com/rails-join-tables/)
- [Mysql2::Error: Column 'created_at' in order clause is ambiguousの対策](https://qiita.com/shunhikita/items/3b6d5ef27d41a047d078)

## 実装画面・機能のキャプチャ
- [TODO一覧ページとタスクの状態による切り替え表示](https://gyazo.com/512835c9578f6937dbcd03018cd20480)
