### PR TITLE
書籍登録時の機能の修正

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -24,7 +24,7 @@ class ReviewsController < ApplicationController
         was_reading = Review.where.not(id: last_review[:id]).find_by(user_id: current_user.id, review_status: "reading")
         was_reading.update(review_status: "stock") if was_reading
       end
-      redirect_to reading_path(current_user)
+      redirect_to review_path(@review)
       flash[:notice] = '本を登録しました'
     else
       flash[:notice] = '正しく入力してください'
@@ -43,7 +43,7 @@ class ReviewsController < ApplicationController
           was_reading = Review.where.not(id: @review[:id]).find_by(user_id: current_user.id, review_status: "reading")
           was_reading.update(review_status: "stock") if was_reading
         end
-        redirect_to reading_path(current_user)
+        redirect_to review_path(@review)
         flash[:notice] = '本の情報を更新しました'
       else
         flash[:notice] = '正しく入力してください'
@@ -60,11 +60,7 @@ class ReviewsController < ApplicationController
   private
 
   def book_params
-    params.require(:book).permit(:title, :author, :image_url, :genre, :url, :isbn)\
-    # book_categories_attributes: [:book_id, :category_id], \
-    # reviews_attributes: [:purpose, :learned, :note, :rate, :review_status, :deadline,\
-    # ,tasks_attributes: [:task_content, :finished]
-    # ]
+    params.require(:book).permit(:title, :author, :image_url, :url, :isbn)
   end
 
   def review_params

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,6 +2,4 @@ class Book < ApplicationRecord
   has_many :reviews, dependent: :restrict_with_error
   accepts_nested_attributes_for :reviews
   validates :title, presence: true
-
-  enum genre: %i[literature nonfiction practical science it art entertainment other]
 end

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -15,9 +15,6 @@
     = book.hidden_field :image_url, value: @book.image_url
   = book.hidden_field :url, value: @book.url
   = book.hidden_field :isbn, value: @book.isbn
--# .form-group.row.review-body__content
--#   = book.label :ジャンル, class:"col-sm-2 col-form-label badge-info"
--#   = book.select :genre, Book.genres_i18n.invert, {}, class: 'form-control col-sm-4', placeholder: 0
 .review-header.review-header__internal
   読書メモ
 .review-body__memo

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -37,12 +37,6 @@
     #star.form-group.row.review-body__content
       = review.label :評価, class: "col-sm-2 col-form-label badge-info star-label"
       = review.hidden_field :rate, id: 'review_star', class: 'form-control col-sm-2', value: 1, max: 5, min: 1
-    -# .review-header.review-header__internal
-    -#   タスク登録
-    -# .review-body__task
-    -#   = fields_for(@task) do |task|
-    -#     .form-group.row.review-body__content
-    -#   -# TODO:ここからタスク
   .form-group.review-submit
     = book.submit "登録する", class: 'btn btn-primary'
 

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -1,9 +1,13 @@
 .form-group.row.review-body__content
-  = book.label :タイトル, class:"col-sm-2 col-form-label badge-info"
-  = book.text_field :title, class: 'form-control col-sm-6 .badge-info', value: @book.title, placeholder: "必須項目"
+  = book.label :タイトル, class: "col-sm-2 col-form-label badge-info"
+  .col-sm-10
+    = @book.title
+  = book.hidden_field :title, value: @book.title
 .form-group.row.review-body__content
-  = book.label :著者, class:"col-sm-2 col-form-label badge-info"
-  = book.text_field :author, class: 'form-control col-sm-6', value: @book.author
+  = book.label :著者, class: "col-sm-2 col-form-label badge-info"
+  .col-sm-10
+    = @book.author
+  = book.hidden_field :author, value: @book.author
 .form-group.row.review-body__content.book-image
   - if @book.image_url.present?
     = book.label :書影, class:"col-sm-2 col-form-label badge-info"
@@ -11,9 +15,9 @@
     = book.hidden_field :image_url, value: @book.image_url
   = book.hidden_field :url, value: @book.url
   = book.hidden_field :isbn, value: @book.isbn
-.form-group.row.review-body__content
-  = book.label :ジャンル, class:"col-sm-2 col-form-label badge-info"
-  = book.select :genre, Book.genres_i18n.invert, {}, class: 'form-control col-sm-4', placeholder: 0
+-# .form-group.row.review-body__content
+-#   = book.label :ジャンル, class:"col-sm-2 col-form-label badge-info"
+-#   = book.select :genre, Book.genres_i18n.invert, {}, class: 'form-control col-sm-4', placeholder: 0
 .review-header.review-header__internal
   読書メモ
 .review-body__memo

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -7,4 +7,4 @@
     書籍情報
   .review-body__book
     = form_with model: @book, url: reviews_path, local: true do |book|  
-      = render partial: 'form', locals: { book: book }  
+      = render partial: 'form', locals: { book: book }

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -40,50 +40,6 @@
         .card-body
           = @review.note
 
-    -# .book-list__reading--bottom
-    -#   .card
-    -#     .card-header
-    -#       レビュー
-    -#       .dropdown.float-right
-    -#         %button{type:"button", class:"btn dropdown-toggle", id:"dropdownMenuButton", "data-toggle":"dropdown", "aria-haspopup":"true", "aria-expanded":"false"}
-    -#         .dropdown-menu{"aria-labelledby":"dropdownMenuButton"}
-    -#           = link_to "編集", edit_review_path(@review), class: "dropdown-item" 
-    -#           = link_to "削除", "/reviews/#{@review.id}", method: :delete, class: "dropdown-item", data: { confirm: "本当に削除しますか？" }
-    -#     .card-body
-    -#       = @review.purpose
-
-
-      -# .book-list__reading--limit
-      -#   .badge.badge-secondary
-      -#     期限
-      -#   .limit
-      -# -#     = @review.deadline.present? ? @review.deadline.strftime('%Y/%m/%d') : "未設定"
-      -#   .badge.badge-secondary
-      -#     ジャンル
-      -#   .genre
-      -#     = @book.genre_i18n
- 
-
-
-    -# .wrapper-book-info.row
-    -#   .wrapper-book-info__image.col-sm-5
-    -#     = image_tag "#{book.image_url}", size: "350x350", alt: "書影"
-    -#   .col-sm-7
-    -#     .wrapper-book-info__title
-    -#       .badge.badge-info.badge-pill
-    -#         タイトル
-    -#       = book.title
-    -#     .wrapper-book-info__author
-    -#       .badge.badge-info.badge-pill
-    -#         著者
-    -#       = book.author
-    -#     .wrapper-book-info__details
-    -#       .badge.badge-info.badge-pill
-    -#         商品詳細
-    -#       = detail.truncate(100)
-    -#     .wrapper-book-info__links
-    -#       = link_to "楽天ブックスで詳細を見る", "#{book.url}"
-
 :erb
   <script>
     $('#star-rate-<%= @review.id %>').raty({

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -15,10 +15,6 @@
           .badge.badge-info.badge-pill
             著者
           = @book.author
-        .wrapper-book-info__genre
-          .badge.badge-info.badge-pill
-            ジャンル
-          = @book.genre_i18n
         .wrapper-book-info__created
           .badge.badge-info.badge-pill
             登録日

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -1,4 +1,6 @@
 .container
+  .flash
+    = render partial: "shared/notification"
   .wrapper-book-info.review-show
     .row
       .wrapper-book-info__image.col-sm-5

--- a/app/views/users/_book-lists.html.haml
+++ b/app/views/users/_book-lists.html.haml
@@ -17,8 +17,6 @@
         = link_to review_path(reviewed_book) do
           = reviewed_book.book.title.truncate(35)
     .card-text
-      .genre
-        = reviewed_book.book.genre_i18n 
       .rate{id: "star-rate-#{reviewed_book.id}"}
 
 :erb

--- a/app/views/users/_reading.html.haml
+++ b/app/views/users/_reading.html.haml
@@ -24,10 +24,6 @@
               期限
             .limit
               = reading_book.deadline.present? ? reading_book.deadline.strftime('%Y/%m/%d') : "未設定"
-            .badge.badge-secondary
-              ジャンル
-            .genre
-              = reading_book.book.genre_i18n
       .book-list__reading--bottom
         .card
           .card-header

--- a/app/views/users/reading.html.haml
+++ b/app/views/users/reading.html.haml
@@ -1,7 +1,5 @@
 .whole-page
   .container
-    = render partial: "shared/notification"
-    -# TODO パンくずリストの追加？
     .row
       = render "shared/sidebar"
       .main-content.col-sm-9.col-md-9

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,15 +1,5 @@
 ja:
   enums:
-    book:
-      genre:
-        literature: "文学・評論"
-        nonfiction: "ノンフィクション"
-        practical: "実用書"
-        science: "サイエンス・テクノロジー"
-        it: "コンピュータ・IT"
-        art: "アート"
-        entertainment: "エンターテインメント"
-        other: "その他"
     review:
       review_status:
         reading: "読書中"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :tasks, only: [:index, :new, :create]
   end
 
-  resources :reviews, only: [:index, :new, :edit, :show]
+  resources :reviews
   
   resources :books, only: :show do
     get :search, on: :collection

--- a/db/migrate/20190816080152_remove_genre_from_books.rb
+++ b/db/migrate/20190816080152_remove_genre_from_books.rb
@@ -1,0 +1,5 @@
+class RemoveGenreFromBooks < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :books, :genre, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_05_135355) do
+ActiveRecord::Schema.define(version: 2019_08_16_080152) do
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 2019_07_05_135355) do
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "genre"
     t.string "url"
     t.string "isbn"
   end
@@ -41,9 +40,9 @@ ActiveRecord::Schema.define(version: 2019_07_05_135355) do
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "task_content", null: false
     t.boolean "finished", default: false, null: false
-    t.bigint "review_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "review_id"
     t.index ["review_id"], name: "index_tasks_on_review_id"
   end
 


### PR DESCRIPTION
## What
書籍の登録・編集時に、
「タイトル」・「著者」について、ユーザーが編集できないようにしました。
また、「ジャンル」に関しては、BOOKSテーブルに保存しないよう仕様を変更しました。

## Why
- [イシューナンバー#21](https://github.com/t-krt/original_app/issues/21)を参照
- ジャンルについては、APIから取得した値を利用する場合、細分化されすぎてしまうという問題があったため、利用を見送った。
（自身の登録した本について、ジャンルによって書籍を検索する際、細分化されていると意図した結果にたどり着きにくいと考えたため。）

## 今回保留した作業と今後のTODO
- ジャンルに代わり、ユーザーが自身で登録できる「Tags」などを活用し、管理を容易にできる手段を検討する。

