### PR TITLE
TODO登録機能の作成

### DIFF
--- a/app/assets/stylesheets/_reviews.scss
+++ b/app/assets/stylesheets/_reviews.scss
@@ -5,6 +5,9 @@
     font-size: 1.1rem;
   }
   .wrapper-book-info {
+    &__right {
+      margin-bottom: 2rem;
+    }
     &__icon {
       padding: 1rem 2rem 1rem 0;
       .icon-color {

--- a/app/assets/stylesheets/_reviews.scss
+++ b/app/assets/stylesheets/_reviews.scss
@@ -1,5 +1,6 @@
 .review-show {
   margin-top: 1rem;
+  padding-bottom: 3rem;
   .badge {
     font-size: 1.1rem;
   }
@@ -10,6 +11,10 @@
         color: #007bff;
         padding-right: 0.5rem;
       }
+    }
+    &--notice {
+      font-size: 0.9rem;
+      color: $accent-color;
     }
   }
 }

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -10,3 +10,8 @@
     font-size: 1.2rem;
   }
 }
+
+.add-task-btn {
+  font-size: 1.55em;
+  padding-bottom: 0.8rem;
+}

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -33,7 +33,11 @@ class ReviewsController < ApplicationController
 
   def edit; end
 
-  def show; end
+  def show
+    tasks = Task.where(review_id: @review.id).order("created_at DESC")
+    @unfinished_tasks = tasks.where(finished: 0).page(params[:page]).per(5)    
+    @finished_tasks = tasks.where(finished: 1).page(params[:page]).per(5)
+  end
 
   def update
     if @review.user_id == current_user.id

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -11,7 +11,6 @@ class ReviewsController < ApplicationController
     @book.title, @book.author, @book.image_url, @book.url, @book.isbn = \
       params[:title], params[:author], params[:image_url], params[:url], params[:isbn]
     @review = Review.new
-    @task = Task.new
   end
 
   def create

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,9 +7,20 @@ class TasksController < ApplicationController
     @finished_task_reviews = reviews.where(tasks: {finished: 1}).page(params[:page]).per(5)
   end
 
-  def new; end
-
-  def create
+  def new
+    @task = Task.new
   end
 
+  def create
+    @task = Task.create(task_params)
+    respond_to do |format|
+      format.html {redirect_to root_path }
+      format.json
+    end
+  end
+
+  private
+  def task_params
+    params.require(:task).permit(:content, :limit).merge(user_id: current_user.id)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,4 +8,8 @@ class TasksController < ApplicationController
   end
 
   def new; end
+
+  def create
+  end
+
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,18 +9,24 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
+    @review = Review.find(params[:review_id])
   end
 
   def create
-    @task = Task.create(task_params)
+    @task = Task.new(task_params)
+
     respond_to do |format|
-      format.html {redirect_to root_path }
-      format.json
+      if @task.save
+        format.js { @status = "success"}
+      else
+        format.js {@status = "fail"}
+      end
     end
   end
 
   private
   def task_params
-    params.require(:task).permit(:content, :limit).merge(user_id: current_user.id)
+    params.require(:task).permit(:content, :limit, :review_id)
+    # params.require(:task).permit(:content, :limit).merge(review_id: @review.id)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
   belongs_to :review
 
-  validates :task_content, presence: true
+  validates :content, presence: true
 end

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -43,10 +43,11 @@
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body
           = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
-    .card-header 
-      この本を読んで行動に移すこと
-      %span.wrapper-book-info--notice （※あなたにしか見えていません）
-    = render 'shared/task-list'
+        .card-header 
+          この本を読んで行動に移すこと
+          %span.wrapper-book-info--notice （※あなたにしか見えていません）
+        .card-body
+          = render 'shared/task-form'
 
 :erb
   <script>

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -9,15 +9,15 @@
         - else
           = image_tag asset_path("no_image.jpg")
       .col-sm-7
-        .wrapper-book-info__title
+        .wrapper-book-info__right
           .badge.badge-info.badge-pill
             タイトル
           = @book.title
-        .wrapper-book-info__author
+        .wrapper-book-info__right
           .badge.badge-info.badge-pill
             著者
           = @book.author
-        .wrapper-book-info__created
+        .wrapper-book-info__right
           .badge.badge-info.badge-pill
             登録日
           = @review.created_at.strftime("%Y/%m/%d")
@@ -46,6 +46,7 @@
     .card-header 
       この本を読んで行動に移すこと
       %span.wrapper-book-info--notice （※あなたにしか見えていません）
+    = render 'shared/task-list'
 
 :erb
   <script>

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -38,7 +38,9 @@
       .card-body
         = @review.learned.present? ? @review.learned : "「学んだこと」は未記入です。"
       - if user_signed_in? && @review.user_id == current_user.id
-        .card-header 読書メモ（※あなたにしか見えていません）
+        .card-header 
+          読書メモ
+          %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body
           = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
 

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -36,11 +36,11 @@
         = @review.purpose
       .card-header 学んだこと
       .card-body
-        = @review.learned
+        = @review.learned.present? ? @review.learned : "「学んだこと」は未記入です。"
       - if user_signed_in? && @review.user_id == current_user.id
         .card-header 読書メモ（※あなたにしか見えていません）
         .card-body
-          = @review.note
+          = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
 
 :erb
   <script>

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -47,8 +47,12 @@
           この本を読んで行動に移すこと
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body
-          = render 'shared/task-form'
-
+          -# review_idがtasks_controllerで必要になるため、パラメータをtasks#newに渡す
+          = link_to new_task_path(params: {review_id: @review.id}), remote: true do 
+            .i.fas.fa-plus-square.add-task-btn
+            -# class: "btn btn-primary mb-3 add-task__btn"
+          #todoModal.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
+          = render 'shared/task-list'
 :erb
   <script>
     $('#star-rate-<%= @review.id %>').raty({

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -43,6 +43,9 @@
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body
           = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
+    .card-header 
+      この本を読んで行動に移すこと
+      %span.wrapper-book-info--notice （※あなたにしか見えていません）
 
 :erb
   <script>

--- a/app/views/shared/_task-form.html.haml
+++ b/app/views/shared/_task-form.html.haml
@@ -1,0 +1,17 @@
+-# / Modal
+.modal-dialog{role: "document"}
+  = form_with model: @task do |f|
+    .modal-content
+      .modal-header
+        #modalLabel.modal-title タスク登録
+      .modal-body
+        .form-group
+          = f.label :タスク
+          = f.text_field :content, class: "form-control"
+        .form-group
+          = f.label :期限
+          = f.date_field :limit, class: 'form-control'
+          = f.hidden_field :review_id, value: review.id
+      .modal-footer
+        %button.btn.btn-secondary{"data-dismiss": "modal", type: "button"} 閉じる
+        = f.submit :"登録する", id: "btnAdd", class: 'btn btn-primary'

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -1,0 +1,27 @@
+/ タブを画面に表示する
+%ul#myTab.nav.nav-tabs{role: "tablist"}
+  %li.nav-item
+    = link_to "未完了のタスク", "#todolist", { id: "#todolist-tab", class:"nav-link active", "aria-controls": "todolist", "aria-selected": "true", "data-toggle": "tab", role: "tab"}
+  %li.nav-item
+    = link_to "完了したタスク", "#complete", { id: "complete-tab", class: "nav-link", "aria-controls": "complete", "aria-selected": "false", "data-toggle": "tab", role: "tab" }
+
+/ タブの中身
+#myTabContent.tab-content
+  / 未完了のタスクリスト
+  #todolist.tab-pane.fade.show.active{"aria-labelledby": "todolist-tab", role: "tabpanel"}
+    .table-responsive
+      %table#todoList.table.table-hover
+        %thead
+          %tr
+            %th タスク内容
+            %th 期限
+        %tbody#new-task
+  / 完了したタスクリスト
+  #complete.tab-pane.fade{"aria-labelledby": "complete-tab", role: "tabpanel"}
+    .table-responsive
+      %table#completeList.table.table-hover
+        %thead
+          %tr
+            %th タスク内容
+            %th 実行日
+        %tbody

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -16,6 +16,14 @@
             %th タスク内容
             %th 期限
         %tbody#new-task
+          - if @unfinished_tasks.present?
+            - @unfinished_tasks.each do |task|
+              %tr
+                %td
+                  = task.content
+                %td
+                  = task.limit.present? ? task.limit : "未設定"
+    = paginate @unfinished_tasks
   / 完了したタスクリスト
   #complete.tab-pane.fade{"aria-labelledby": "complete-tab", role: "tabpanel"}
     .table-responsive
@@ -23,5 +31,12 @@
         %thead
           %tr
             %th タスク内容
-            %th 実行日
+            %th 実行日時
         %tbody
+          - if @finished_tasks.present?
+            - @finished_tasks.each do |task|
+              %tr
+                %td
+                  = task.content
+                %td
+                  = task.updated_at.strftime("%Y-%m-%d %H:%M")

--- a/app/views/tasks/_task-tr.html.haml
+++ b/app/views/tasks/_task-tr.html.haml
@@ -1,0 +1,7 @@
+%tr
+  %td
+    = task.content
+  %td
+    = task.limit.present? ? task.limit : "未設定"
+  -# %td= link_to 'Show', task
+  -# %td= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?'}

--- a/app/views/tasks/create.js.erb
+++ b/app/views/tasks/create.js.erb
@@ -1,0 +1,6 @@
+<% if @status == 'success' %>
+  $("#new-task").append("<%= j(render("task-tr", task: @task)) %>");
+  $("#todoModal").modal("hide");
+<%  elsif @status == 'fail' %>
+  alert('タスクを入力してください');
+<% end %>

--- a/app/views/tasks/create.js.erb
+++ b/app/views/tasks/create.js.erb
@@ -1,5 +1,5 @@
 <% if @status == 'success' %>
-  $("#new-task").append("<%= j(render("task-tr", task: @task)) %>");
+  $("#new-task").prepend("<%= j(render("task-tr", task: @task)) %>");
   $("#todoModal").modal("hide");
 <%  elsif @status == 'fail' %>
   alert('タスクを入力してください');

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -18,7 +18,7 @@
                       = simple_format(review.book.title) 
                   .card-body.task-index__tasks
                     - review.tasks.each do |task|
-                      = simple_format(task.task_content)
+                      = simple_format(task.content)
               - else 
                 未完了のタスクはありません。
             = paginate(@unfinished_task_reviews)

--- a/app/views/tasks/new.html.haml
+++ b/app/views/tasks/new.html.haml
@@ -1,2 +1,0 @@
-%h1 Tasks#new
-%p Find me in app/views/tasks/new.html.haml

--- a/app/views/tasks/new.js.erb
+++ b/app/views/tasks/new.js.erb
@@ -1,0 +1,2 @@
+$("#todoModal").html("<%= escape_javascript(render 'shared/task-form', {review: @review}) %>")
+$("#todoModal").modal("show")

--- a/app/views/users/_book-lists.html.haml
+++ b/app/views/users/_book-lists.html.haml
@@ -1,4 +1,4 @@
-.col-sm-4.book-lists__cards
+.col-sm-6.col-md-4.book-lists__cards
   .card.img-thumbnail
     .card-image-top
     - if reviewed_book.book.image_url.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,10 @@ Rails.application.routes.draw do
     member do 
       get :reading, :read, :stock
     end
-    resources :tasks, only: [:index, :new, :create]
+    resources :tasks, only: [:index]
   end
 
+  resources :tasks, except: [:index, :show]
   resources :reviews
   
   resources :books, only: :show do

--- a/db/migrate/20190823082821_add_limit_to_tasks.rb
+++ b/db/migrate/20190823082821_add_limit_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddLimitToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :limit, :date
+  end
+end

--- a/db/migrate/20190823083125_rename_task_content_column_to_tasks.rb
+++ b/db/migrate/20190823083125_rename_task_content_column_to_tasks.rb
@@ -1,0 +1,5 @@
+class RenameTaskContentColumnToTasks < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :tasks, :task_content, :content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_16_080152) do
+ActiveRecord::Schema.define(version: 2019_08_23_083125) do
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
@@ -38,11 +38,12 @@ ActiveRecord::Schema.define(version: 2019_08_16_080152) do
   end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "task_content", null: false
+    t.string "content", null: false
     t.boolean "finished", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "review_id"
+    t.date "limit"
     t.index ["review_id"], name: "index_tasks_on_review_id"
   end
 


### PR DESCRIPTION
## What
TODO登録機能を追加しました。

## Why
「本を読んで行動に移したいこと」の登録機能が、サービスに必須であるため。

## How
- レビュー詳細画面から、タスクを追加できるようにしました。
- モーダルウィンドウを採用し、form_withを活用した非同期通信で実装しました。
- tasksテーブルへの登録時に必要な「review_id」の値は、link_toメソッドのオプションを活用し、レビュー詳細画面から、tasks#newアクションへparamsを引き継ぐことで対応しました。

## 今回保留した作業と今後のTODO
- タスクの更新（update）機能の追加
- タスクの変更（edit）機能の追加
- タスクの削除（destroy）機能の追加
- レビューごとのタスクの一覧表示機能の追加

## 備考（実装にあたって参考にした情報など）
- [Railsで remote: true と js.erbを使って簡単にAjax(非同期通信)を実装しよう！(いいね機能のデモ付)](https://qiita.com/__tambo__/items/45211df065e0c037d032)
- [Rails5と BootstrapでAjax-modalform](https://qiita.com/niwaken/items/ffbce52fb024fd369f24)
- [ajaxのエラー(500 internal server error)の解決方法](https://egapool.hatenablog.com/entry/2016/09/03/163307) ⬅️ ajaxのデバッグの際に、参考になりました。

## 実装画面・機能のキャプチャ
[タスク登録機能のGIF](https://gyazo.com/8990020bdb544aac9b37f8c36ee0684b)