### PR TITLE
Create task manegement function#28

### DIFF
--- a/app/assets/stylesheets/_reviews.scss
+++ b/app/assets/stylesheets/_reviews.scss
@@ -20,6 +20,13 @@
       color: $accent-color;
     }
   }
+  &__contents {
+    &__list {
+      &--no-entry {
+        color: gray;
+      }
+    }
+  }
 }
 
 .user-info {

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -30,6 +30,19 @@
     width: 30%;
   }
   &__right {
-    width: 50px;
+    width: 5rem;
+  }
+  &__left-finished {
+    width: 3rem;
+  }
+  &__right-finished {
+    width: 5rem;
+  }
+}
+
+.finished_task{
+  &__content {
+    color: gray;
+    text-decoration: line-through;
   }
 }

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -13,5 +13,7 @@
 
 .add-task-btn {
   font-size: 1.55em;
-  padding-bottom: 0.8rem;
+  line-height: 1;
+  padding: 5px 0.5rem 5px 0;
+  vertical-align: middle;
 }

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -17,3 +17,19 @@
   padding: 5px 0.5rem 5px 0;
   vertical-align: middle;
 }
+
+.task-list-icon {
+  padding-right: 1rem;
+}
+
+.task-table {
+  &__left {
+    width: 110px;
+  }
+  &__limit {
+    width: 30%;
+  }
+  &__right {
+    width: 50px;
+  }
+}

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -34,9 +34,9 @@ class ReviewsController < ApplicationController
   def edit; end
 
   def show
-    tasks = Task.where(review_id: @review.id).order("created_at DESC")
-    @unfinished_tasks = tasks.where(finished: 0).page(params[:page]).per(5)    
-    @finished_tasks = tasks.where(finished: 1).page(params[:page]).per(5)
+    tasks = Task.where(review_id: @review.id)
+    @unfinished_tasks = tasks.order("created_at DESC").where(finished: 0).page(params[:page]).per(5)    
+    @finished_tasks = tasks.order("updated_at DESC").where(finished: 1).page(params[:page]).per(5)
   end
 
   def update

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -25,6 +25,16 @@ class TasksController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+
   private
   def task_params
     params.require(:task).permit(:content, :limit, :review_id)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,6 +27,5 @@ class TasksController < ApplicationController
   private
   def task_params
     params.require(:task).permit(:content, :limit, :review_id)
-    # params.require(:task).permit(:content, :limit).merge(review_id: @review.id)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_task, only: [:edit, :update, :destroy]
 
   def index
     reviews = Review.where(user_id: current_user.id).order("reviews.created_at DESC").includes(:book, :tasks)
@@ -27,5 +28,9 @@ class TasksController < ApplicationController
   private
   def task_params
     params.require(:task).permit(:content, :limit, :review_id)
+  end
+
+  def set_task
+    @task = Task.find(params[:id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_task, only: [:edit, :update, :destroy]
+  before_action :set_task, only: [:edit, :update, :destroy, :finish]
   before_action :set_review, only: [:new, :edit]
 
   def index
@@ -41,6 +41,16 @@ class TasksController < ApplicationController
   def destroy
     respond_to do |format|
       if @task.destroy
+        format.js { @status = "success"}
+      else
+        format.js {@status = "fail"}
+      end
+    end
+  end
+
+  def finish
+    respond_to do |format|
+      if @task.update(finished: true)
         format.js { @status = "success"}
       else
         format.js {@status = "fail"}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -39,6 +39,13 @@ class TasksController < ApplicationController
   end
 
   def destroy
+    respond_to do |format|
+      if @task.destroy
+        format.js { @status = "success"}
+      else
+        format.js {@status = "fail"}
+      end
+    end
   end
 
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_task, only: [:edit, :update, :destroy]
+  before_action :set_review, only: [:new, :edit]
 
   def index
     reviews = Review.where(user_id: current_user.id).order("reviews.created_at DESC").includes(:book, :tasks)
@@ -10,7 +11,6 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
-    @review = Review.find(params[:review_id])
   end
 
   def create
@@ -29,6 +29,13 @@ class TasksController < ApplicationController
   end
 
   def update
+    respond_to do |format|
+      if @task.update(task_params)
+        format.js { @status = "success"}
+      else
+        format.js {@status = "fail"}
+      end
+    end
   end
 
   def destroy
@@ -42,5 +49,9 @@ class TasksController < ApplicationController
 
   def set_task
     @task = Task.find(params[:id])
+  end
+
+  def set_review
+    @review = Review.find(params[:review_id])
   end
 end

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -54,9 +54,9 @@
           = link_to new_task_path(params: {review_id: @review.id}), remote: true do 
             .i.fas.fa-plus-square.add-task-btn
           TODOを追加する
+          #todoModal.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body.review-show__contents__list 
-          #todoModal.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
           = render 'shared/task-list'
 :erb
   <script>

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -30,26 +30,32 @@
               %i.fas.fa-trash-alt.fa-lg.icon-color
           = link_to "#{@book.url}" do
             %i.fas.fa-info-circle.fa-lg.icon-color
-    .card
+    .card.review-show__contents
       .card-header 読書の目的
-      .card-body 
+      .card-body.review-show__contents__list 
         = @review.purpose
       .card-header 学んだこと
-      .card-body
-        = @review.learned.present? ? @review.learned : "「学んだこと」は未記入です。"
+      .card-body.review-show__contents__list 
+        - if @review.learned.present?
+          = @review.learned
+        - else
+          .review-show__contents__list--no-entry 「学んだこと」は未記入です。
       - if user_signed_in? && @review.user_id == current_user.id
         .card-header 
           読書メモ
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
-        .card-body
-          = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
+        .card-body.review-show__contents__list 
+          - if @review.note.present?
+            = @review.note 
+          - else
+            .review-show__contents__list--no-entry 「読書メモ」は未記入です。
         .card-header 
           -# review_idがtasks_controllerで必要になるため、パラメータをtasks#newに渡す
           = link_to new_task_path(params: {review_id: @review.id}), remote: true do 
             .i.fas.fa-plus-square.add-task-btn
           TODOを追加する
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
-        .card-body
+        .card-body.review-show__contents__list 
           #todoModal.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
           = render 'shared/task-list'
 :erb

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -44,13 +44,12 @@
         .card-body
           = @review.note.present? ? @review.note :  "「読書メモ」は未記入です。"
         .card-header 
-          この本を読んで行動に移すこと
-          %span.wrapper-book-info--notice （※あなたにしか見えていません）
-        .card-body
           -# review_idがtasks_controllerで必要になるため、パラメータをtasks#newに渡す
           = link_to new_task_path(params: {review_id: @review.id}), remote: true do 
             .i.fas.fa-plus-square.add-task-btn
-            -# class: "btn btn-primary mb-3 add-task__btn"
+          TODOを追加する
+          %span.wrapper-book-info--notice （※あなたにしか見えていません）
+        .card-body
           #todoModal.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
           = render 'shared/task-list'
 :erb

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -50,7 +50,7 @@
           - else
             .review-show__contents__list--no-entry 「読書メモ」は未記入です。
         .card-header 
-          -# review_idがtasks_controllerで必要になるため、パラメータをtasks#newに渡す
+          -# review_idがtasks_controllerのset_reviewメソッドで必要になるため、パラメータをtasks#newに渡す
           = link_to new_task_path(params: {review_id: @review.id}), remote: true do 
             .i.fas.fa-plus-square.add-task-btn
           TODOを追加する

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -36,7 +36,7 @@
                   = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
                     %i.fas.fa-trash-alt.icon-color
           - else
-            %td
+            %td.have-no-tasks
             %td.have-no-tasks 未完了のタスクはありません
     = paginate @unfinished_tasks
   / 完了したタスクリスト

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -12,17 +12,29 @@
     .table-responsive
       %table#todoList.table.table-hover
         %thead
-          %tr.table-info
+          %tr.table-info.task-table
+            %th.task-table__left
             %th タスク内容
-            %th 期限
+            %th.task-table__limit 期限
+            %th.task-table__right
         %tbody#new-task
           - if @unfinished_tasks.present?
             - @unfinished_tasks.each do |task|
               %tr
+                %td.task-table-left
+                  -# finishedの値を更新する
+                  = link_to task_path(task), class: "task-list-icon", remote: true do
+                    %i.far.fa-check-circle
+                  -# check後のアイコン %i.fas.fa-check-circle
+                  = link_to edit_task_path(task), class: "task-list-icon", remote: true do
+                    %i.fas.fa-pen
                 %td
                   = task.content
                 %td
                   = task.limit.present? ? task.limit : "未設定"
+                %td
+                  = link_to "/reviews/#{task.id}", method: :delete, remote: true do
+                    %i.fas.fa-trash-alt.icon-color
     = paginate @unfinished_tasks
   / 完了したタスクリスト
   #complete.tab-pane.fade{"aria-labelledby": "complete-tab", role: "tabpanel"}

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -12,7 +12,7 @@
     .table-responsive
       %table#todoList.table.table-hover
         %thead
-          %tr
+          %tr.table-info
             %th タスク内容
             %th 期限
         %tbody#new-task
@@ -29,7 +29,7 @@
     .table-responsive
       %table#completeList.table.table-hover
         %thead
-          %tr
+          %tr.table-info
             %th タスク内容
             %th 実行日時
         %tbody

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -25,7 +25,7 @@
                   -# finishedの値を更新する
                   = link_to finish_task_path(task), class: "task-list-icon task-#{task.id}-check-link", remote: true do
                     %i.far.fa-check-circle{class: "task-#{task.id}-check"}
-                  = link_to edit_task_path(task, params: {review_id: @review.id}), class: "task-list-icon", remote: true do
+                  = link_to edit_task_path(task, params: {review_id: @review.id}), class: "task-list-icon task-#{task.id}-check-link", remote: true do
                     %i.fas.fa-pen
                   #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
                 %td{class: "task-#{task.id}-content"}

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -35,6 +35,9 @@
                 %td
                   = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
                     %i.fas.fa-trash-alt.icon-color
+          - else
+            %td
+            %td.have-no-tasks 未完了のタスクはありません
     = paginate @unfinished_tasks
   / 完了したタスクリスト
   #complete.tab-pane.fade{"aria-labelledby": "complete-tab", role: "tabpanel"}
@@ -58,4 +61,7 @@
                 %td
                   = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
                     %i.fas.fa-trash-alt.icon-color
+          - else
+            %td
+            %td 完了したタスクはありません
     = paginate @finished_tasks

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -29,9 +29,9 @@
                   = link_to edit_task_path(task, params: {review_id: @review.id}), class: "task-list-icon", remote: true do
                     %i.fas.fa-pen
                   #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
-                %td
+                %td{class: "task-#{task.id}-content"}
                   = task.content
-                %td
+                %td{class: "task-#{task.id}-limit"}
                   = task.limit.present? ? task.limit : "未設定"
                 %td
                   = link_to "/reviews/#{task.id}", method: :delete, remote: true do

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -20,7 +20,7 @@
         %tbody#new-task
           - if @unfinished_tasks.present?
             - @unfinished_tasks.each do |task|
-              %tr
+              %tr{id: "task-#{task.id}-all"}
                 %td.task-table-left
                   -# finishedの値を更新する
                   = link_to task_path(task), class: "task-list-icon", remote: true do
@@ -34,7 +34,7 @@
                 %td{class: "task-#{task.id}-limit"}
                   = task.limit.present? ? task.limit : "未設定"
                 %td
-                  = link_to "/reviews/#{task.id}", method: :delete, remote: true do
+                  = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
                     %i.fas.fa-trash-alt.icon-color
     = paginate @unfinished_tasks
   / 完了したタスクリスト

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -42,14 +42,20 @@
     .table-responsive
       %table#completeList.table.table-hover
         %thead
-          %tr.table-info
+          %tr.table-info.task-table
+            %th.task-table__left-finished
             %th タスク内容
-            %th 実行日時
-        %tbody
+            %th.task-table__limit 実行日時
+            %th.task-table__right-finished
+        %tbody.finished_task
           - if @finished_tasks.present?
             - @finished_tasks.each do |task|
-              %tr
+              %tr{id: "task-#{task.id}-all"}
                 %td
+                %td.finished_task__content
                   = task.content
                 %td
                   = task.updated_at.strftime("%Y-%m-%d %H:%M")
+                %td
+                  = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
+                    %i.fas.fa-trash-alt.icon-color

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -26,8 +26,9 @@
                   = link_to task_path(task), class: "task-list-icon", remote: true do
                     %i.far.fa-check-circle
                   -# check後のアイコン %i.fas.fa-check-circle
-                  = link_to edit_task_path(task), class: "task-list-icon", remote: true do
+                  = link_to edit_task_path(task, params: {review_id: @review.id}), class: "task-list-icon", remote: true do
                     %i.fas.fa-pen
+                  #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
                 %td
                   = task.content
                 %td

--- a/app/views/shared/_task-list.html.haml
+++ b/app/views/shared/_task-list.html.haml
@@ -23,9 +23,8 @@
               %tr{id: "task-#{task.id}-all"}
                 %td.task-table-left
                   -# finishedの値を更新する
-                  = link_to task_path(task), class: "task-list-icon", remote: true do
-                    %i.far.fa-check-circle
-                  -# check後のアイコン %i.fas.fa-check-circle
+                  = link_to finish_task_path(task), class: "task-list-icon task-#{task.id}-check-link", remote: true do
+                    %i.far.fa-check-circle{class: "task-#{task.id}-check"}
                   = link_to edit_task_path(task, params: {review_id: @review.id}), class: "task-list-icon", remote: true do
                     %i.fas.fa-pen
                   #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
@@ -59,3 +58,4 @@
                 %td
                   = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
                     %i.fas.fa-trash-alt.icon-color
+    = paginate @finished_tasks

--- a/app/views/tasks/_task-tr.html.haml
+++ b/app/views/tasks/_task-tr.html.haml
@@ -1,7 +1,14 @@
 %tr
-  %td
+  %td.task-table-left
+    = link_to task_path(task), class: "task-list-icon", remote: true do
+      %i.far.fa-check-circle
+    = link_to edit_task_path(task, params: {review_id: review_id}), class: "task-list-icon", remote: true do
+      %i.fas.fa-pen
+    #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
+  %td{class: "task-#{task.id}-content"}
     = task.content
-  %td
+  %td{class: "task-#{task.id}-limit"}
     = task.limit.present? ? task.limit : "未設定"
-  -# %td= link_to 'Show', task
-  -# %td= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?'}
+  %td
+    = link_to "/reviews/#{task.id}", method: :delete, remote: true do
+      %i.fas.fa-trash-alt.icon-color

--- a/app/views/tasks/_task-tr.html.haml
+++ b/app/views/tasks/_task-tr.html.haml
@@ -1,7 +1,7 @@
 %tr{id: "task-#{task.id}-all"}
   %td.task-table-left
-    = link_to task_path(task), class: "task-list-icon", remote: true do
-      %i.far.fa-check-circle
+    = link_to finish_task_path(task), class: "task-list-icon task-#{task.id}-check-link", remote: true do
+      %i.far.fa-check-circle{class: "task-#{task.id}-check"}
     = link_to edit_task_path(task, params: {review_id: review_id}), class: "task-list-icon", remote: true do
       %i.fas.fa-pen
     #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}

--- a/app/views/tasks/_task-tr.html.haml
+++ b/app/views/tasks/_task-tr.html.haml
@@ -1,4 +1,4 @@
-%tr
+%tr{id: "task-#{task.id}-all"}
   %td.task-table-left
     = link_to task_path(task), class: "task-list-icon", remote: true do
       %i.far.fa-check-circle
@@ -10,5 +10,5 @@
   %td{class: "task-#{task.id}-limit"}
     = task.limit.present? ? task.limit : "未設定"
   %td
-    = link_to "/reviews/#{task.id}", method: :delete, remote: true do
+    = link_to task_path(task), method: :delete, data: { confirm: 'タスクを削除しますか？' }, remote: true do
       %i.fas.fa-trash-alt.icon-color

--- a/app/views/tasks/_task-tr.html.haml
+++ b/app/views/tasks/_task-tr.html.haml
@@ -2,7 +2,7 @@
   %td.task-table-left
     = link_to finish_task_path(task), class: "task-list-icon task-#{task.id}-check-link", remote: true do
       %i.far.fa-check-circle{class: "task-#{task.id}-check"}
-    = link_to edit_task_path(task, params: {review_id: review_id}), class: "task-list-icon", remote: true do
+    = link_to edit_task_path(task, params: {review_id: review_id}), class: "task-list-icon task-#{task.id}-check-link", remote: true do
       %i.fas.fa-pen
     #todoModal-edit.modal{"aria-hidden": "true", "aria-labelledby": "exampleModalLabel", role: "dialog", tabindex: "-1"}
   %td{class: "task-#{task.id}-content"}

--- a/app/views/tasks/create.js.erb
+++ b/app/views/tasks/create.js.erb
@@ -1,5 +1,5 @@
 <% if @status == 'success' %>
-  $("#new-task").prepend("<%= j(render("task-tr", task: @task)) %>");
+  $("#new-task").prepend("<%= j(render("task-tr", task: @task, review_id: @task.review_id )) %>");
   $("#todoModal").modal("hide");
 <%  elsif @status == 'fail' %>
   alert('タスクを入力してください');

--- a/app/views/tasks/create.js.erb
+++ b/app/views/tasks/create.js.erb
@@ -1,5 +1,6 @@
 <% if @status == 'success' %>
   $("#new-task").prepend("<%= j(render("task-tr", task: @task, review_id: @task.review_id )) %>");
+  $('.have-no-tasks').remove();
   $("#todoModal").modal("hide");
 <%  elsif @status == 'fail' %>
   alert('タスクを入力してください');

--- a/app/views/tasks/destroy.js.erb
+++ b/app/views/tasks/destroy.js.erb
@@ -1,0 +1,8 @@
+task = <%== @task.to_json %>
+console.log(task);
+
+<% if @status == 'success' %>
+  $(`#task-${task.id}-all`).remove();
+<%  elsif @status == 'fail' %>
+  alert('タスクの削除に失敗しました');
+<% end %>

--- a/app/views/tasks/edit.js.erb
+++ b/app/views/tasks/edit.js.erb
@@ -1,0 +1,2 @@
+$("#todoModal-edit").html("<%= escape_javascript(render 'shared/task-form', {review: @review}) %>")
+$("#todoModal-edit").modal("show")

--- a/app/views/tasks/finish.js.erb
+++ b/app/views/tasks/finish.js.erb
@@ -1,0 +1,12 @@
+task = <%== @task.to_json %>
+
+<% if @status == 'success' %>
+  <%# チェックのアイコンを更新 %>
+  $(`.task-${task.id}-check`).removeClass('far').addClass('fas');
+  <%# リンクを無効化 %>
+  $(`.task-${task.id}-check-link`).css('pointer-events', 'none');
+  <%# クラスの追加により打ち消し線を付与 %>
+  $(`.task-${task.id}-content`).addClass("finished_task__content");
+<%  elsif @status == 'fail' %>
+  alert('タスクのチェックに失敗しました');
+<% end %>

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -30,7 +30,7 @@
                       = simple_format(review.book.title) 
                   .card-body.task-index__tasks
                     - review.tasks.each do |task|
-                      = simple_format(task.task_content)
+                      = simple_format(task.content)
               - else 
                 完了済みのタスクはありません。
             = paginate(@finished_task_reviews)

--- a/app/views/tasks/update.js.erb
+++ b/app/views/tasks/update.js.erb
@@ -1,0 +1,11 @@
+task = <%== @task.to_json %>
+
+<% if @status == 'success' %>
+  <%# タスク内容の書き換え %>
+  $(`.task-${task.id}-content`).html("<%= @task.content %>");
+  <%# 期限の書き換え %>
+  $(`.task-${task.id}-limit`).html("<%= @task.limit.present? ? @task.limit : "未設定" %>");
+  $("#todoModal-edit").modal("hide");
+<%  elsif @status == 'fail' %>
+  alert('タスクを入力してください');
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
     resources :tasks, only: [:index]
   end
 
-  resources :tasks, except: [:index, :show]
+  resources :tasks, except: [:index, :show] do
+    get :finish, on: :member
+  end
   resources :reviews
   
   resources :books, only: :show do


### PR DESCRIPTION
## What
登録したレビューに対し、タスクを設定できる機能を追加しました。
登録・編集・削除、および状態の更新（未完了→完了のみ）ができます。

## Why
読書して行動に移したいと思ったことを、簡単に管理できるようにするため。

## How
js.erbファイルを活用し、上記の機能をAjax（非同期通信）で実行できるようにしました。

## 今回保留した作業と今後のTODO
- マイページで、登録したタスクを一覧で表示できるページを作成する

## 備考（実装にあたって参考にした情報など）
- [Railsで remote: true と js.erbを使って簡単にAjax(非同期通信)を実装しよう！(いいね機能のデモ付)](https://qiita.com/__tambo__/items/45211df065e0c037d032)
- [Ajax(非同期通信)についてわかりやすさ重視でまとめてみた(Rails使用のデモ付)](https://qiita.com/__tambo__/items/409ccf256e84017ea307)

## 実装画面・機能のキャプチャ
- [（GIF）タスクの登録](https://gyazo.com/d0bc5aea46265aafa3933fdcef1c6f38)
- [（GIF）タスクの編集](https://gyazo.com/21c3095d5b92dd4572ac613b18afa278)
- [（GIF）タスクの削除](https://gyazo.com/49a9960781986497fc2c114076852055)
- [（GIF）タスクの完了](https://gyazo.com/ac5bcddeb54c8a84e0cbeec8b8d9686c)