### PR TITLE
かんたんログイン機能の実装

### DIFF
--- a/app/assets/stylesheets/_share.scss
+++ b/app/assets/stylesheets/_share.scss
@@ -1,5 +1,5 @@
 .notification {
-  background-color: #07575B;
+  background-color: #E0162E;
   color: white;
   text-align: center;
 }

--- a/app/assets/stylesheets/_top.scss
+++ b/app/assets/stylesheets/_top.scss
@@ -84,7 +84,13 @@
       width: 60%;
     }
   }
-  .easy-login {
+  &__links {
     margin-bottom: 30px;
+    &__user--left {
+      margin-right: 0.5rem;
+    }
+    &__guest {
+      margin: 2rem 0 1rem 0;
+    }
   }
 }

--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -101,3 +101,6 @@
   font-size: 20px;
 }
 
+.guide-message {
+  padding: 2rem 0 0.5rem 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_resource)
-    reading_path(current_user)
+    reading_user_path(current_user)
   end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -25,7 +25,7 @@
           = f.label :avatar
           = f.file_field :avatar, class: 'custom-file'
         .form-group
-          = f.submit t('.update'), class: 'btn btn-primary'
+          = f.submit t('.update'), class: 'btn btn-info'
       %p
-        #{link_to t('.cancel_my_account'), registration_path(resource_name), class: 'btn btn-primary', data: { confirm: t('.are_you_sure') }, method: :delete}
-      = link_to t('.back'), :back, class: 'btn btn-primary'
+        #{link_to t('.cancel_my_account'), registration_path(resource_name), class: 'btn btn-info', data: { confirm: t('.are_you_sure') }, method: :delete}
+      = link_to t('.back'), reading_user_path(current_user), class: 'btn btn-info'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -22,5 +22,7 @@
           = f.label :avatar
           = f.file_field :avatar, class: 'custom-file'
         .form-group
-          = f.submit t('.sign_up'), class: 'btn btn-primary'
+          = f.submit ('登録する'), class: 'btn btn-info'
+
+      .guide-message 既にアカウントをお持ちですか？
       = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -15,5 +15,12 @@
             = f.label :remember_me, class: 'form-check-label' do
               = resource.class.human_attribute_name('remember_me')
         .form-group
-          = f.submit  t('.sign_in'), class: 'btn btn-primary'
+          = f.submit  ('ログインする'), class: 'btn btn-info'
+
+      = form_for(resource, as: resource_name, url: user_session_path) do |f|
+        = f.hidden_field :email, {value: 'guest-user@guest.com'}
+        = f.hidden_field :password, {value: 'guest123'}
+        = f.submit "かんたんログイン", class: "btn btn-info easy-login"
+        %p ※ポートフォリオ観覧用のテストユーザーでログインします。
+
       = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -23,4 +23,5 @@
         = f.submit "かんたんログイン", class: "btn btn-info easy-login"
         %p ※ポートフォリオ観覧用のテストユーザーでログインします。
 
+      .guide-message アカウントをお持ちでないですか？
       = render 'devise/shared/links'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,20 +1,20 @@
 .form-group
   - if controller_name != 'sessions'
-    = link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-primary"
+    = link_to ("ログイン"), new_session_path(resource_name), class: "btn btn-info confirmation-message__btn"
     %p
   - if devise_mapping.registerable? && controller_name != 'registrations'
-    = link_to t(".sign_up"), new_registration_path(resource_name), class: "btn btn-primary"
+    = link_to ("アカウント登録"), new_registration_path(resource_name), class: "btn btn-info confirmation-message__btn"
     %p
-  - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-    = link_to t(".forgot_your_password"), new_password_path(resource_name), class: "btn btn-primary"
-    %p
-  - if devise_mapping.confirmable? && controller_name != 'confirmations'
-    = link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name), class: "btn btn-primary"
-    %p
-  - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-    = link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: "btn btn-primary"
-    %p
-  - if devise_mapping.omniauthable?
-    - resource_class.omniauth_providers.each do |provider|
-      = link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: "btn btn-primary"
-      %br/
+  -# - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  -#   = link_to t(".forgot_your_password"), new_password_path(resource_name), class: "btn btn-primary"
+  -#   %p
+  -# - if devise_mapping.confirmable? && controller_name != 'confirmations'
+  -#   = link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name), class: "btn btn-primary"
+  -#   %p
+  -# - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  -#   = link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: "btn btn-primary"
+  -#   %p
+  -# - if devise_mapping.omniauthable?
+  -#   - resource_class.omniauth_providers.each do |provider|
+  -#     = link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: "btn btn-primary"
+  -#     %br/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,5 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render partial: 'shared/header'
+    = render partial: "shared/notification"
     = yield

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -1,6 +1,4 @@
 .container
-  .flash
-    = render partial: "shared/notification"
   .wrapper-book-info.review-show
     .row
       .wrapper-book-info__image.col-sm-5

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -24,5 +24,9 @@
           %i.fas.fa-tasks.fa-3x
         .top-content__description--text
           %p タスク管理
-          %p 学んだことを行動に移しましょう。
-    =link_to "かんたんログイン", "#", class: "btn btn-info btn-lg easy-login"
+    .top-content__links
+      .top-content__links__user
+        = link_to "アカウント登録", new_user_registration_path, class: "btn btn-info btn-lg top-content__links__user--left"
+        = link_to "ログイン", new_user_session_path, class: "btn btn-info btn-lg"
+      .top-content__links__guest
+        = link_to "投稿一覧を見る", reviews_path, class: "btn btn-info btn-lg top-content__links__link"

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -24,6 +24,7 @@
           %i.fas.fa-tasks.fa-3x
         .top-content__description--text
           %p タスク管理
+          %p 学んだことを行動に移しましょう。
     .top-content__links
       .top-content__links__user
         = link_to "アカウント登録", new_user_registration_path, class: "btn btn-info btn-lg top-content__links__user--left"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -42,13 +42,14 @@ ja:
         send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
     registrations:
       edit:
-        are_you_sure: "本当に良いですか?"
+        are_you_sure: "アカウントを削除します。本当に良いですか?"
         cancel_my_account: "アカウント削除"
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
         title: "登録情報の変更"
         unhappy: "気に入りません"
         update: "更新"
+        back: "マイページへ戻る"
         we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
       new:
         sign_up: "アカウント登録"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-	
-3.times { Task.create!(task_content: 'Sample Task', review_id: 1) }
-2.times { Task.create!(task_content: 'Sample Task finished', finished: true, review_id: 2) }
+User.create!(
+  nickname:              'ゲストユーザー',
+  email:                 'guest-user@guest.co'
+  password:              "guest123",
+  password_confirmation: "guest123"
+)


### PR DESCRIPTION
## What
「かんたんログイン」機能を実装しました。
また、それに伴い、アカウント登録・ログイン等に関するページを修正しました。

## Why
ポートフォリオサイトとしての機能を、簡易に確認していただけるようにするため。

## How
hidden_fieldを活用し、「かんたんログイン」のボタンをクリックした際に、
deviseのsessions_controllerのcreateアクションにゲストユーザーのemail・passwordがPOSTされるようにしました。

## 今回保留した作業と今後のTODO
- ログインページ・アカウント登録ページのビューを調整（優先順位低）

## 実装画面・機能のキャプチャ
- [（GIF）「かんたんログイン」を利用したログイン](https://gyazo.com/8d6ec468486a310c984affdc9535d0d4)