### PR TITLE
投稿一覧画面のビュー修正#41

### DIFF
--- a/app/assets/stylesheets/_reviews.scss
+++ b/app/assets/stylesheets/_reviews.scss
@@ -29,34 +29,39 @@
   }
 }
 
-.user-info {
-  font-size: 0.9rem;
-  padding-left: 1rem;
-  &--others {
-    text-align: right;
-    padding-right: 1rem;
-  }
-}
-
-.review-info-box {
-  font-size: 0.9rem;
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1rem;
-  padding-right: 1.5rem;
-  &__body {
-    background-color: #f8f8f8;
-  }
-  .right__author {
-    margin-bottom: 1rem;
-  }
-}
-
 .review-index {
   .badge {
     margin-top: 0;
     margin-right: 0.9rem;
     display: inline;
     font-size: 0.9rem;
+  }
+
+  .user-info {
+    font-size: 0.9rem;
+    padding-left: 1rem;
+    &__right {
+      &__learned {
+        padding: 1rem 1rem 1rem 0;
+      }
+      &__others {
+      text-align: right;
+      padding-right: 1rem;
+      }
+    }
+  }
+
+  .review-info-box {
+    font-size: 0.9rem;
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+    padding-right: 1.5rem;
+    &__body {
+      background-color: #f8f8f8;
+    }
+    .right__author {
+      margin-bottom: 1rem;
+    }
   }
 }

--- a/app/assets/stylesheets/_reviews.scss
+++ b/app/assets/stylesheets/_reviews.scss
@@ -42,11 +42,32 @@
     padding-left: 1rem;
     &__right {
       &__learned {
-        padding: 1rem 1rem 1rem 0;
+        padding: 0 1rem 1rem 0;
+        &__upper {
+          display: flex;
+          justify-content: space-between;
+          &--label {
+            font-size: 1rem;
+          }
+          .badge {
+            margin-right: 0;
+          }
+        }
+        &--content {
+          padding-left: 1.5rem;
+          &--none {
+            color: gray;
+          }
+        }
       }
       &__others {
-      text-align: right;
-      padding-right: 1rem;
+        font-size: 0.9rem;
+        text-align: right;
+        padding-right: 1rem;
+        &--name {
+          display: inline-block;
+          padding-left: 0.5rem;
+        }
       }
     }
   }

--- a/app/views/reviews/_review.html.haml
+++ b/app/views/reviews/_review.html.haml
@@ -3,18 +3,19 @@
     .user-info__left.col-sm-2
       = image_tag review.user.avatar.url
     .user-info__right.col-sm-10
-      .user_info--ro-review-show
+      .user_info__right__review-show
         = link_to "詳しく見る", review_path(review), class: "badge badge-info float-right"
-      .user-info--name
+      .user-info__right__name
         = review.user.nickname
-      .user-info--review
-        = review.learned.present? ? review.learned : "レビューはありません"
-      .user-info--others
+        さん
+      .user-info__right__learned
+        = review.learned.present? ? review.learned : "「学んだこと」は未記入です"
+      .user-info__right__others
         = review.created_at.strftime("%Y/%m/%d")
         - if review.rate.present?
-          .rate{id: "star-rate-#{review.id}"}
+          .user-info__right__others--rate.rate{id: "star-rate-#{review.id}"}
         - else
-          .rate 未評価
+          .user-info__right__others--rate.rate 未評価
   .review-info-box
     .row.col-sm-10.review-info-box__body
       .review-info-box__body--left.col-sm-3

--- a/app/views/reviews/_review.html.haml
+++ b/app/views/reviews/_review.html.haml
@@ -3,19 +3,27 @@
     .user-info__left.col-sm-2
       = image_tag review.user.avatar.url
     .user-info__right.col-sm-10
-      .user_info__right__review-show
-        = link_to "詳しく見る", review_path(review), class: "badge badge-info float-right"
-      .user-info__right__name
-        = review.user.nickname
-        さん
       .user-info__right__learned
-        = review.learned.present? ? review.learned : "「学んだこと」は未記入です"
+        .user-info__right__learned__upper
+          .user-info__right__learned__upper--label
+            学んだこと
+          .user-info__right__learned__upper--badge
+            = link_to "詳しく見る", review_path(review), class: "badge badge-info float-right"
+        .user-info__right__learned--content
+          - if review.learned.present? 
+            = review.learned.truncate(280) 
+          - else 
+            .user-info__right__learned--content--none 「学んだこと」は未記入です。
       .user-info__right__others
         = review.created_at.strftime("%Y/%m/%d")
+        .user-info__right__others--name
+          = review.user.nickname
+          さん
         - if review.rate.present?
           .user-info__right__others--rate.rate{id: "star-rate-#{review.id}"}
         - else
           .user-info__right__others--rate.rate 未評価
+
   .review-info-box
     .row.col-sm-10.review-info-box__body
       .review-info-box__body--left.col-sm-3

--- a/app/views/reviews/_review.html.haml
+++ b/app/views/reviews/_review.html.haml
@@ -11,7 +11,10 @@
         = review.learned.present? ? review.learned : "レビューはありません"
       .user-info--others
         = review.created_at.strftime("%Y/%m/%d")
-        .rate{id: "star-rate-#{review.id}"}
+        - if review.rate.present?
+          .rate{id: "star-rate-#{review.id}"}
+        - else
+          .rate 未評価
   .review-info-box
     .row.col-sm-10.review-info-box__body
       .review-info-box__body--left.col-sm-3

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -1,8 +1,7 @@
 .whole-page
   .container
     .row
-      = render "shared/sidebar"
-      .main-content.col-sm-9.col-md-9.card
+      .main-content.col-sm-12.col-md-12.card
         .card-header
           みんなの感想・レビュー
         .card-body

--- a/app/views/reviews/index.html.haml
+++ b/app/views/reviews/index.html.haml
@@ -3,7 +3,7 @@
     .row
       .main-content.col-sm-12.col-md-12.card
         .card-header
-          みんなの感想・レビュー
+          みんなの投稿一覧
         .card-body
           - @reviews.each do |review|
             = render partial: "review", locals: { review: review }

--- a/app/views/users/_reading.html.haml
+++ b/app/views/users/_reading.html.haml
@@ -18,7 +18,8 @@
             .badge.badge-secondary
               タイトル
             .title
-              = reading_book.book.title
+              = link_to review_path(reading_book.id) do
+                = reading_book.book.title
           .book-list__reading--limit
             .badge.badge-secondary
               期限


### PR DESCRIPTION
## What
投稿一覧画面のビューについて、表示内容・順番等を修正しました。
また、非ログイン時でも確認できるようにしました。

## Why
ユーザーの利便性を向上するため。

## 実装画面・機能のキャプチャ
- [編集後の投稿一覧画面](https://gyazo.com/2139b006d45d4d7bbf8f68286d5b602c)